### PR TITLE
Restore otherArgs usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dragongoose/streamlink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Streamlink wrapper for Node.js",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,10 @@ export class Streamlink extends EventEmitter {
       args.push("--stdout");
     }
 
+    if (this.options.otherArgs && this.options.otherArgs.length > 0) {
+      args.push(...this.options.otherArgs)
+    }
+
     args.push(this.stream);
     args.push(this.qual);
     this.startTime = Date.now();


### PR DESCRIPTION
Currently the ``StreamlinkOptions.otherArgs`` field isn't used and additional options can't be given to Streamlink, this simply append the ``otherArgs`` array before the stream source.